### PR TITLE
ISSUE-23-change-subpage-header

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -34,7 +34,7 @@ const Footer: React.FC = () => {
   const classes = useStyles(useTheme());
 
   return (
-    <Paper className={classes.root}>
+    <Paper className={classes.root} square>
       <Container maxWidth="lg" className={classes.content}>
         <Typography variant="body1" className={classes.copyright}>
           © 2021 April Neufeld

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import { useRouter } from 'next/router';
-import MenuIcon from '@mui/icons-material/Menu';
+import MenuRoundedIcon from '@mui/icons-material/MenuRounded';
 import useScrollTrigger from '@mui/material/useScrollTrigger';
 import { Tabs, tabsClasses, Tab, AppBar, Toolbar, IconButton, Drawer, Paper, Theme, useTheme } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
@@ -28,9 +28,13 @@ const useStyles = makeStyles((theme: Theme) => ({
     justifyContent: 'center',
   },
   drawerButton: {
+    color: theme.palette.grey[100],
     [theme.breakpoints.up('md')]: {
       display: 'none',
     },
+  },
+  drawerButtonElevated: {
+    color: theme.palette.text.secondary,
   },
   drawer: {
     [theme.breakpoints.up('md')]: {
@@ -142,7 +146,7 @@ const Header: React.FC<Props> = (props) => {
   });
 
   return (
-    <Paper className={classes.root}>
+    <Paper className={classes.root} square>
       <AppBar
         className={clsx(classes.appBar, {
           [classes.appBarElevated]: scrolled,
@@ -161,8 +165,14 @@ const Header: React.FC<Props> = (props) => {
             ))}
             ;
           </Tabs>
-          <IconButton className={classes.drawerButton} color="default" onClick={handleDrawerToggle} size="large">
-            <MenuIcon />
+          <IconButton
+            className={clsx(classes.drawerButton, {
+              [classes.drawerButtonElevated]: scrolled,
+            })}
+            onClick={handleDrawerToggle}
+            size="large"
+          >
+            <MenuRoundedIcon fontSize="large" />
           </IconButton>
           <Drawer className={classes.drawer} anchor="top" open={drawerOpen} onClose={handleDrawerToggle}>
             <Tabs

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,92 +1,16 @@
-import * as React from 'react';
-import clsx from 'clsx';
-import { useRouter } from 'next/router';
-import MenuRoundedIcon from '@mui/icons-material/MenuRounded';
-import useScrollTrigger from '@mui/material/useScrollTrigger';
-import { Tabs, tabsClasses, Tab, AppBar, Toolbar, IconButton, Drawer, Paper, Theme, useTheme } from '@mui/material';
+import { Paper, useTheme } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
-import { Page } from '../shared/types';
+import * as React from 'react';
+import HeaderNavBar from './HeaderNavBar';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles(() => ({
   root: {
     zIndex: 2,
     backgroundImage: "url('/images/background.png')",
     backgroundRepeat: 'no-repeat',
     backgroundSize: 'cover',
   },
-  tabsLayout: {
-    [theme.breakpoints.down('md')]: {
-      visibility: 'hidden',
-    },
-  },
-  tabsLayoutVertical: {
-    [`& .${tabsClasses.flexContainerVertical}`]: {
-      alignItems: 'center',
-    },
-  },
-  toolbar: {
-    justifyContent: 'center',
-  },
-  drawerButton: {
-    color: theme.palette.grey[100],
-    [theme.breakpoints.up('md')]: {
-      display: 'none',
-    },
-  },
-  drawerButtonElevated: {
-    color: theme.palette.text.secondary,
-  },
-  drawer: {
-    [theme.breakpoints.up('md')]: {
-      visibility: 'hidden',
-    },
-  },
-  /*
-   * When we are at the top of the screen.
-   */
-  appBar: {
-    backgroundColor: 'transparent',
-    zIndex: 10,
-    boxShadow: 'none',
-    color: theme.palette.grey[100],
-    transition: theme.transitions.create(['background-color', 'z-index', 'box-shadow', 'color'], {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-  },
-  /*
-   * When we have scrolled down.
-   */
-  appBarElevated: {
-    backgroundColor: 'white',
-    zIndex: 40,
-    boxShadow: theme.shadows[4],
-    color: theme.palette.text.primary,
-    transition: theme.transitions.create(['background-color', 'z-index', 'box-shadow', 'color'], {
-      easing: theme.transitions.easing.easeOut,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-  },
 }));
-
-/**
- * The collection of pages that we
- * want to render.
- */
-const pages: Page[] = [
-  {
-    path: '/',
-    title: 'Home',
-  },
-  {
-    path: '/projects',
-    title: 'My Work',
-  },
-  {
-    path: '/blog',
-    title: 'Blog',
-  },
-];
 
 interface Props {
   children?: React.ReactNode;
@@ -94,104 +18,15 @@ interface Props {
 
 /**
  * A header component that holds a navigation menu above arbitrary
- * header content. The nav menu consists of material-ui Tabs. When a Tab
- * is selected, the new path is pushed to browser history.
- *
- * While at the top of the page, the nav menu has a transparent background
- * and is overlaid atop the content.
- *
- * When the user scrolls down, the nav menu elevates above the rest of the
- * header and the page content, and it transitions to an opaque background
- * and contrasting foreground.
+ * header content.
  */
 const Header: React.FC<Props> = (props) => {
   const { children } = props;
-  const router = useRouter();
-  const [drawerOpen, setDrawerOpen] = React.useState(false);
   const classes = useStyles(useTheme());
-
-  // Find out which tab should be shown as selected based on the current
-  // router path. If the path does not exist as part of our array, it's
-  // one of our blog posts, so show the Blog tab as selected.
-  const tabValue = React.useRef(
-    pages.findIndex((page) => router.pathname === page.path) >= 0
-      ? pages.findIndex((page) => router.pathname === page.path)
-      : 2,
-  );
-
-  /**
-   * Handles a selection of a menu item by
-   * pushing the new path to browser history.
-   *
-   * @param newValue the tab index of the selected item.
-   */
-  const handleMenuSelection = (event: React.SyntheticEvent<{}>, newValue: number) => {
-    router.push(pages[newValue].path);
-  };
-
-  /**
-   * Handles selection of the hamburger menu
-   * icon in mobile.
-   */
-  const handleDrawerToggle = () => {
-    setDrawerOpen(!drawerOpen);
-  };
-
-  /**
-   * Handles a scroll event.
-   */
-  const scrolled = useScrollTrigger({
-    disableHysteresis: true,
-    threshold: 0,
-  });
 
   return (
     <Paper className={classes.root} square>
-      <AppBar
-        className={clsx(classes.appBar, {
-          [classes.appBarElevated]: scrolled,
-        })}
-      >
-        <Toolbar className={classes.toolbar}>
-          <Tabs
-            value={tabValue.current}
-            onChange={handleMenuSelection}
-            className={classes.tabsLayout}
-            indicatorColor="secondary"
-            textColor="inherit"
-          >
-            {pages.map((page: Page) => (
-              <Tab sx={{ minWidth: 160 }} key={page.title} label={page.title} />
-            ))}
-            ;
-          </Tabs>
-          <IconButton
-            className={clsx(classes.drawerButton, {
-              [classes.drawerButtonElevated]: scrolled,
-            })}
-            onClick={handleDrawerToggle}
-            size="large"
-          >
-            <MenuRoundedIcon fontSize="large" />
-          </IconButton>
-          <Drawer className={classes.drawer} anchor="top" open={drawerOpen} onClose={handleDrawerToggle}>
-            <Tabs
-              value={tabValue.current}
-              onChange={handleMenuSelection}
-              orientation="vertical"
-              className={classes.tabsLayoutVertical}
-              indicatorColor="secondary"
-              textColor="inherit"
-            >
-              {pages.map((page: Page) => (
-                <Tab key={page.title} label={page.title} onClick={handleDrawerToggle} />
-              ))}
-              ;
-            </Tabs>
-          </Drawer>
-        </Toolbar>
-      </AppBar>
-      <Toolbar />
+      <HeaderNavBar />
       {children}
     </Paper>
   );

--- a/src/components/HeaderBioContent.tsx
+++ b/src/components/HeaderBioContent.tsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       paddingTop: theme.spacing(1),
     },
     [theme.breakpoints.up('md')]: {
-      paddingTop: theme.spacing(6),
+      paddingTop: theme.spacing(3),
     },
     position: 'relative',
     color: theme.palette.common.white,

--- a/src/components/HeaderBioContent.tsx
+++ b/src/components/HeaderBioContent.tsx
@@ -66,7 +66,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const HeaderContent: React.FC = () => {
+const HeaderBioContent: React.FC = () => {
   const user = useApplicationState((state) => state.user);
   const classes = useStyles(useTheme());
 
@@ -104,4 +104,4 @@ const HeaderContent: React.FC = () => {
   );
 };
 
-export default HeaderContent;
+export default HeaderBioContent;

--- a/src/components/HeaderNavBar.tsx
+++ b/src/components/HeaderNavBar.tsx
@@ -1,0 +1,188 @@
+import * as React from 'react';
+import clsx from 'clsx';
+import { useRouter } from 'next/router';
+import MenuRoundedIcon from '@mui/icons-material/MenuRounded';
+import useScrollTrigger from '@mui/material/useScrollTrigger';
+import { Tabs, tabsClasses, Tab, AppBar, Toolbar, IconButton, Drawer, Paper, Theme, useTheme } from '@mui/material';
+import makeStyles from '@mui/styles/makeStyles';
+import { Page } from '../shared/types';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  tabsLayout: {
+    [theme.breakpoints.down('md')]: {
+      visibility: 'hidden',
+    },
+  },
+  tabsLayoutVertical: {
+    [`& .${tabsClasses.flexContainerVertical}`]: {
+      alignItems: 'center',
+    },
+  },
+  toolbar: {
+    justifyContent: 'center',
+  },
+  drawerButton: {
+    color: theme.palette.grey[100],
+    [theme.breakpoints.up('md')]: {
+      display: 'none',
+    },
+  },
+  drawerButtonElevated: {
+    color: theme.palette.text.secondary,
+  },
+  drawer: {
+    [theme.breakpoints.up('md')]: {
+      visibility: 'hidden',
+    },
+  },
+  /*
+   * When we are at the top of the screen.
+   */
+  appBar: {
+    backgroundColor: 'transparent',
+    zIndex: 10,
+    boxShadow: 'none',
+    color: theme.palette.grey[100],
+    transition: theme.transitions.create(['background-color', 'z-index', 'box-shadow', 'color'], {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+  },
+  /*
+   * When we have scrolled down.
+   */
+  appBarElevated: {
+    backgroundColor: 'white',
+    zIndex: 40,
+    boxShadow: theme.shadows[4],
+    color: theme.palette.text.primary,
+    transition: theme.transitions.create(['background-color', 'z-index', 'box-shadow', 'color'], {
+      easing: theme.transitions.easing.easeOut,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+  },
+}));
+
+/**
+ * The collection of pages that we
+ * want to render.
+ */
+const pages: Page[] = [
+  {
+    path: '/',
+    title: 'Home',
+  },
+  {
+    path: '/projects',
+    title: 'My Work',
+  },
+  {
+    path: '/blog',
+    title: 'Blog',
+  },
+];
+
+/**
+ * A header component that holds a navigation menu above arbitrary
+ * header content. The nav menu consists of material-ui Tabs. When a Tab
+ * is selected, the new path is pushed to browser history.
+ *
+ * While at the top of the page, the nav menu has a transparent background
+ * and is overlaid atop the content.
+ *
+ * When the user scrolls down, the nav menu elevates above the rest of the
+ * header and the page content, and it transitions to an opaque background
+ * and contrasting foreground.
+ */
+const HeaderNavBar: React.FC = () => {
+  const router = useRouter();
+  const [drawerOpen, setDrawerOpen] = React.useState(false);
+  const classes = useStyles(useTheme());
+
+  // Find out which tab should be shown as selected based on the current
+  // router path. If the path does not exist as part of our array, it's
+  // one of our blog posts, so show the Blog tab as selected.
+  const tabValue = React.useRef(
+    pages.findIndex((page) => router.pathname === page.path) >= 0
+      ? pages.findIndex((page) => router.pathname === page.path)
+      : 2,
+  );
+
+  /**
+   * Handles a selection of a menu item by
+   * pushing the new path to browser history.
+   *
+   * @param newValue the tab index of the selected item.
+   */
+  const handleMenuSelection = (event: React.SyntheticEvent<{}>, newValue: number) => {
+    router.push(pages[newValue].path);
+  };
+
+  /**
+   * Handles selection of the hamburger menu
+   * icon in mobile.
+   */
+  const handleDrawerToggle = () => {
+    setDrawerOpen(!drawerOpen);
+  };
+
+  /**
+   * Handles a scroll event.
+   */
+  const scrolled = useScrollTrigger({
+    disableHysteresis: true,
+    threshold: 0,
+  });
+
+  return (
+    <React.Fragment>
+      <AppBar
+        className={clsx(classes.appBar, {
+          [classes.appBarElevated]: scrolled,
+        })}
+      >
+        <Toolbar className={classes.toolbar}>
+          <Tabs
+            value={tabValue.current}
+            onChange={handleMenuSelection}
+            className={classes.tabsLayout}
+            indicatorColor="secondary"
+            textColor="inherit"
+          >
+            {pages.map((page: Page) => (
+              <Tab sx={{ minWidth: 160 }} key={page.title} label={page.title} />
+            ))}
+            ;
+          </Tabs>
+          <IconButton
+            className={clsx(classes.drawerButton, {
+              [classes.drawerButtonElevated]: scrolled,
+            })}
+            onClick={handleDrawerToggle}
+            size="large"
+          >
+            <MenuRoundedIcon fontSize="large" />
+          </IconButton>
+          <Drawer className={classes.drawer} anchor="top" open={drawerOpen} onClose={handleDrawerToggle}>
+            <Tabs
+              value={tabValue.current}
+              onChange={handleMenuSelection}
+              orientation="vertical"
+              className={classes.tabsLayoutVertical}
+              indicatorColor="secondary"
+              textColor="inherit"
+            >
+              {pages.map((page: Page) => (
+                <Tab key={page.title} label={page.title} onClick={handleDrawerToggle} />
+              ))}
+              ;
+            </Tabs>
+          </Drawer>
+        </Toolbar>
+      </AppBar>
+      <Toolbar />
+    </React.Fragment>
+  );
+};
+
+export default HeaderNavBar;

--- a/src/components/HeaderNavBar.tsx
+++ b/src/components/HeaderNavBar.tsx
@@ -3,23 +3,35 @@ import clsx from 'clsx';
 import { useRouter } from 'next/router';
 import MenuRoundedIcon from '@mui/icons-material/MenuRounded';
 import useScrollTrigger from '@mui/material/useScrollTrigger';
-import { Tabs, tabsClasses, Tab, AppBar, Toolbar, IconButton, Drawer, Paper, Theme, useTheme } from '@mui/material';
+import Image from 'next/image';
+import {
+  Box,
+  Tabs,
+  tabsClasses,
+  Tab,
+  AppBar,
+  Toolbar,
+  IconButton,
+  Drawer,
+  Theme,
+  useTheme,
+  Typography,
+  Container,
+  toolbarClasses,
+} from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import { Page } from '../shared/types';
 
 const useStyles = makeStyles((theme: Theme) => ({
   tabsLayout: {
     [theme.breakpoints.down('md')]: {
-      visibility: 'hidden',
+      display: 'none',
     },
   },
   tabsLayoutVertical: {
     [`& .${tabsClasses.flexContainerVertical}`]: {
       alignItems: 'center',
     },
-  },
-  toolbar: {
-    justifyContent: 'center',
   },
   drawerButton: {
     color: theme.palette.grey[100],
@@ -32,8 +44,27 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   drawer: {
     [theme.breakpoints.up('md')]: {
-      visibility: 'hidden',
+      display: 'none',
     },
+  },
+  profilePictureContainer: {
+    height: 50,
+    width: 50,
+    border: 1,
+    borderColor: theme.palette.grey[100],
+    borderStyle: 'solid',
+    borderRadius: 300,
+    backgroundColor: '#ffffff4D',
+    marginRight: theme.spacing(2),
+    [theme.breakpoints.down('sm')]: {
+      display: 'none',
+    },
+  },
+  profilePictureContainerElevated: {
+    borderColor: theme.palette.grey[800],
+  },
+  profilePicture: {
+    borderRadius: 300,
   },
   /*
    * When we are at the top of the screen.
@@ -82,18 +113,6 @@ const pages: Page[] = [
   },
 ];
 
-/**
- * A header component that holds a navigation menu above arbitrary
- * header content. The nav menu consists of material-ui Tabs. When a Tab
- * is selected, the new path is pushed to browser history.
- *
- * While at the top of the page, the nav menu has a transparent background
- * and is overlaid atop the content.
- *
- * When the user scrolls down, the nav menu elevates above the rest of the
- * header and the page content, and it transitions to an opaque background
- * and contrasting foreground.
- */
 const HeaderNavBar: React.FC = () => {
   const router = useRouter();
   const [drawerOpen, setDrawerOpen] = React.useState(false);
@@ -108,27 +127,14 @@ const HeaderNavBar: React.FC = () => {
       : 2,
   );
 
-  /**
-   * Handles a selection of a menu item by
-   * pushing the new path to browser history.
-   *
-   * @param newValue the tab index of the selected item.
-   */
   const handleMenuSelection = (event: React.SyntheticEvent<{}>, newValue: number) => {
     router.push(pages[newValue].path);
   };
 
-  /**
-   * Handles selection of the hamburger menu
-   * icon in mobile.
-   */
   const handleDrawerToggle = () => {
     setDrawerOpen(!drawerOpen);
   };
 
-  /**
-   * Handles a scroll event.
-   */
   const scrolled = useScrollTrigger({
     disableHysteresis: true,
     threshold: 0,
@@ -141,46 +147,66 @@ const HeaderNavBar: React.FC = () => {
           [classes.appBarElevated]: scrolled,
         })}
       >
-        <Toolbar className={classes.toolbar}>
-          <Tabs
-            value={tabValue.current}
-            onChange={handleMenuSelection}
-            className={classes.tabsLayout}
-            indicatorColor="secondary"
-            textColor="inherit"
-          >
-            {pages.map((page: Page) => (
-              <Tab sx={{ minWidth: 160 }} key={page.title} label={page.title} />
-            ))}
-            ;
-          </Tabs>
-          <IconButton
-            className={clsx(classes.drawerButton, {
-              [classes.drawerButtonElevated]: scrolled,
-            })}
-            onClick={handleDrawerToggle}
-            size="large"
-          >
-            <MenuRoundedIcon fontSize="large" />
-          </IconButton>
-          <Drawer className={classes.drawer} anchor="top" open={drawerOpen} onClose={handleDrawerToggle}>
+        <Container maxWidth="lg" sx={{ display: 'flex', minHeight: 80 }}>
+          <Toolbar sx={{ justifyContent: 'space-between', flexGrow: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              <Box
+                className={clsx(classes.profilePictureContainer, {
+                  [classes.profilePictureContainerElevated]: scrolled,
+                })}
+              >
+                <Image
+                  src="/images/avatar.png"
+                  className={classes.profilePicture}
+                  width={'100%'}
+                  height={'100%'}
+                  layout="responsive"
+                  priority
+                  alt="Profile avatar"
+                />
+              </Box>
+              <Typography sx={{ fontSize: '1.2rem', letterSpacing: '0.05em' }}>aprilNeufeld</Typography>
+            </Box>
             <Tabs
               value={tabValue.current}
               onChange={handleMenuSelection}
-              orientation="vertical"
-              className={classes.tabsLayoutVertical}
+              className={classes.tabsLayout}
               indicatorColor="secondary"
               textColor="inherit"
             >
               {pages.map((page: Page) => (
-                <Tab key={page.title} label={page.title} onClick={handleDrawerToggle} />
+                <Tab sx={{ minWidth: 100 }} key={page.title} label={page.title} />
               ))}
               ;
             </Tabs>
-          </Drawer>
-        </Toolbar>
+            <IconButton
+              className={clsx(classes.drawerButton, {
+                [classes.drawerButtonElevated]: scrolled,
+              })}
+              onClick={handleDrawerToggle}
+              size="large"
+            >
+              <MenuRoundedIcon fontSize="inherit" />
+            </IconButton>
+            <Drawer className={classes.drawer} anchor="top" open={drawerOpen} onClose={handleDrawerToggle}>
+              <Tabs
+                value={tabValue.current}
+                onChange={handleMenuSelection}
+                orientation="vertical"
+                className={classes.tabsLayoutVertical}
+                indicatorColor="secondary"
+                textColor="inherit"
+              >
+                {pages.map((page: Page) => (
+                  <Tab key={page.title} label={page.title} onClick={handleDrawerToggle} />
+                ))}
+                ;
+              </Tabs>
+            </Drawer>
+          </Toolbar>
+        </Container>
       </AppBar>
-      <Toolbar />
+      <Toolbar sx={{ height: 80 }} />
     </React.Fragment>
   );
 };

--- a/src/components/HeaderNavBar.tsx
+++ b/src/components/HeaderNavBar.tsx
@@ -17,10 +17,10 @@ import {
   useTheme,
   Typography,
   Container,
-  toolbarClasses,
 } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import { Page } from '../shared/types';
+import { theme } from '../styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
   tabsLayout: {
@@ -33,42 +33,23 @@ const useStyles = makeStyles((theme: Theme) => ({
       alignItems: 'center',
     },
   },
-  drawerButton: {
-    color: theme.palette.grey[100],
-    [theme.breakpoints.up('md')]: {
-      display: 'none',
-    },
-  },
-  drawerButtonElevated: {
-    color: theme.palette.text.secondary,
-  },
-  drawer: {
-    [theme.breakpoints.up('md')]: {
-      display: 'none',
-    },
-  },
   profilePictureContainer: {
     height: 50,
     width: 50,
     border: 1,
-    borderColor: theme.palette.grey[100],
     borderStyle: 'solid',
     borderRadius: 300,
     backgroundColor: '#ffffff4D',
     marginRight: theme.spacing(2),
     [theme.breakpoints.down('sm')]: {
-      display: 'none',
+      height: 30,
+      width: 30,
+      marginRight: theme.spacing(1),
     },
-  },
-  profilePictureContainerElevated: {
-    borderColor: theme.palette.grey[800],
   },
   profilePicture: {
     borderRadius: 300,
   },
-  /*
-   * When we are at the top of the screen.
-   */
   appBar: {
     backgroundColor: 'transparent',
     zIndex: 10,
@@ -79,9 +60,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       duration: theme.transitions.duration.leavingScreen,
     }),
   },
-  /*
-   * When we have scrolled down.
-   */
   appBarElevated: {
     backgroundColor: 'white',
     zIndex: 40,
@@ -94,10 +72,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-/**
- * The collection of pages that we
- * want to render.
- */
 const pages: Page[] = [
   {
     path: '/',
@@ -135,6 +109,10 @@ const HeaderNavBar: React.FC = () => {
     setDrawerOpen(!drawerOpen);
   };
 
+  const navigateToHome = () => {
+    router.push('/');
+  };
+
   const scrolled = useScrollTrigger({
     disableHysteresis: true,
     threshold: 0,
@@ -148,12 +126,29 @@ const HeaderNavBar: React.FC = () => {
         })}
       >
         <Container maxWidth="lg" sx={{ display: 'flex', minHeight: 80 }}>
-          <Toolbar sx={{ justifyContent: 'space-between', flexGrow: 1 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <Toolbar
+            sx={{
+              justifyContent: 'space-between',
+              flexGrow: 1,
+              px: {
+                xs: theme.spacing(0),
+              },
+            }}
+          >
+            <Box
+              onClick={navigateToHome}
+              sx={{ display: 'flex', alignItems: 'center', pl: theme.spacing(1), cursor: 'pointer' }}
+            >
               <Box
-                className={clsx(classes.profilePictureContainer, {
-                  [classes.profilePictureContainerElevated]: scrolled,
-                })}
+                className={classes.profilePictureContainer}
+                sx={[
+                  {
+                    borderColor: theme.palette.grey[100],
+                  },
+                  scrolled && {
+                    borderColor: theme.palette.grey[800],
+                  },
+                ]}
               >
                 <Image
                   src="/images/avatar.png"
@@ -165,7 +160,17 @@ const HeaderNavBar: React.FC = () => {
                   alt="Profile avatar"
                 />
               </Box>
-              <Typography sx={{ fontSize: '1.2rem', letterSpacing: '0.05em' }}>aprilNeufeld</Typography>
+              <Typography
+                sx={{
+                  fontSize: {
+                    xs: '1rem',
+                    sm: '1.2rem',
+                  },
+                  letterSpacing: '0.05em',
+                }}
+              >
+                aprilNeufeld
+              </Typography>
             </Box>
             <Tabs
               value={tabValue.current}
@@ -180,15 +185,21 @@ const HeaderNavBar: React.FC = () => {
               ;
             </Tabs>
             <IconButton
-              className={clsx(classes.drawerButton, {
-                [classes.drawerButtonElevated]: scrolled,
-              })}
               onClick={handleDrawerToggle}
               size="large"
+              sx={[
+                {
+                  color: theme.palette.grey[100],
+                  display: { md: 'none' },
+                },
+                scrolled && {
+                  color: theme.palette.text.secondary,
+                },
+              ]}
             >
               <MenuRoundedIcon fontSize="inherit" />
             </IconButton>
-            <Drawer className={classes.drawer} anchor="top" open={drawerOpen} onClose={handleDrawerToggle}>
+            <Drawer sx={{ display: { md: 'none' } }} anchor="top" open={drawerOpen} onClose={handleDrawerToggle}>
               <Tabs
                 value={tabValue.current}
                 onChange={handleMenuSelection}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -24,9 +24,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       boxShadow: 'none',
     },
   },
-  contentExpandedPadding: {
-    //paddingTop: theme.spacing(15),
-  },
 }));
 
 interface Props {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import Head from 'next/head';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
-import PageTitle from '../components/PageTitle';
 import { Container, Paper, Theme, useTheme } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import HeaderBioContent from './HeaderBioContent';
@@ -25,50 +24,48 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   content: {
-    paddingTop: theme.spacing(6),
-    paddingBottom: theme.spacing(6),
     [theme.breakpoints.up('md')]: {
       paddingRight: theme.spacing(6),
       paddingLeft: theme.spacing(6),
+      paddingTop: theme.spacing(10),
+      paddingBottom: theme.spacing(10),
     },
     [theme.breakpoints.down('md')]: {
       paddingRight: 0,
       paddingLeft: 0,
+      paddingTop: theme.spacing(6),
+      paddingBottom: theme.spacing(6),
     },
+  },
+  contentExpandedPadding: {
+    //paddingTop: theme.spacing(15),
   },
 }));
 
 interface Props {
   children?: React.ReactNode;
   pageTitle: string;
-  contentTitle?: string;
+  showBioContent?: boolean;
   preview?: boolean;
 }
 
 const Layout: React.FC<Props> = (props) => {
-  const { children, pageTitle, contentTitle, preview } = props;
+  const { children, pageTitle, showBioContent, preview } = props;
   const classes = useStyles(useTheme());
 
   return (
     <React.Fragment>
       <Head>
-        <title>{preview ? pageTitle + ' Preview' : pageTitle}</title>
+        <title>{`${pageTitle} - AprilNeufeld.ca`}</title>
         <meta charSet="utf-8" />
         <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       </Head>
       <React.Fragment>
-        {!preview && (
-          <Header>
-            <HeaderBioContent />
-          </Header>
-        )}
+        {!preview && <Header>{showBioContent && <HeaderBioContent />}</Header>}
         <Container maxWidth="lg" className={classes.root}>
           <Paper elevation={2} className={classes.paper}>
             <Container maxWidth="md" className={classes.content}>
-              <div>
-                {contentTitle && <PageTitle text={contentTitle} />}
-                {children}
-              </div>
+              {children}
             </Container>
           </Paper>
         </Container>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,6 +5,7 @@ import Footer from '../components/Footer';
 import { Container, Paper, Theme, useTheme } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import HeaderBioContent from './HeaderBioContent';
+import { theme } from '../styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -21,20 +22,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     flexBasis: 'auto',
     [theme.breakpoints.down('md')]: {
       boxShadow: 'none',
-    },
-  },
-  content: {
-    [theme.breakpoints.up('md')]: {
-      paddingRight: theme.spacing(6),
-      paddingLeft: theme.spacing(6),
-      paddingTop: theme.spacing(10),
-      paddingBottom: theme.spacing(10),
-    },
-    [theme.breakpoints.down('md')]: {
-      paddingRight: 0,
-      paddingLeft: 0,
-      paddingTop: theme.spacing(6),
-      paddingBottom: theme.spacing(6),
     },
   },
   contentExpandedPadding: {
@@ -64,7 +51,27 @@ const Layout: React.FC<Props> = (props) => {
         {!preview && <Header>{showBioContent && <HeaderBioContent />}</Header>}
         <Container maxWidth="lg" className={classes.root}>
           <Paper elevation={2} className={classes.paper}>
-            <Container maxWidth="md" className={classes.content}>
+            <Container
+              maxWidth="md"
+              sx={[
+                {
+                  px: {
+                    xs: theme.spacing(0),
+                    md: theme.spacing(6),
+                  },
+                  py: {
+                    xs: theme.spacing(6),
+                    md: theme.spacing(10),
+                  },
+                },
+                !showBioContent && {
+                  py: {
+                    xs: theme.spacing(8),
+                    lg: theme.spacing(12),
+                  },
+                },
+              ]}
+            >
               {children}
             </Container>
           </Paper>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,7 +5,7 @@ import Footer from '../components/Footer';
 import PageTitle from '../components/PageTitle';
 import { Container, Paper, Theme, useTheme } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
-import HeaderContent from '../components/HeaderContent';
+import HeaderBioContent from './HeaderBioContent';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -59,7 +59,7 @@ const Layout: React.FC<Props> = (props) => {
       <React.Fragment>
         {!preview && (
           <Header>
-            <HeaderContent />
+            <HeaderBioContent />
           </Header>
         )}
         <Container maxWidth="lg" className={classes.root}>

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -1,15 +1,7 @@
+import { Typography } from '@mui/material';
 import * as React from 'react';
-import { Typography, Theme, useTheme } from '@mui/material';
 
-import makeStyles from '@mui/styles/makeStyles';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  title: {
-    marginBottom: theme.spacing(4),
-    color: theme.palette.primary.main,
-    lineHeight: 1.5,
-  },
-}));
+import { theme } from '../styles';
 
 interface Props {
   text: string;
@@ -17,11 +9,18 @@ interface Props {
 
 const PageTitle: React.FC<Props> = (props) => {
   const { text } = props;
-  const classes = useStyles(useTheme());
 
   return (
     <React.Fragment>
-      <Typography variant="overline" gutterBottom className={classes.title} component="div">
+      <Typography
+        variant="overline"
+        component="div"
+        sx={{
+          pb: theme.spacing(4),
+          color: theme.palette.primary.main,
+          lineHeight: 1.5,
+        }}
+      >
         {text}
       </Typography>
     </React.Fragment>

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -24,7 +24,14 @@ const Blog: React.FC = () => {
     <React.Fragment>
       <Layout pageTitle="Blog">
         <PageTitle text="Blog" />
-        <Box sx={{ mt: theme.spacing(4) }}>
+        <Box
+          sx={{
+            mt: {
+              xs: theme.spacing(2),
+              md: theme.spacing(4),
+            },
+          }}
+        >
           {blog.loaded ? (
             blog.posts.map((post: any, index: number) => <BlogPostCard key={index} post={post} />)
           ) : (

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -6,6 +6,7 @@ import { fetchUserState } from '../lib/staticFetching';
 import { useApplicationState, useAppDispatch } from '../store';
 import { fetchBlogPosts } from '../store/blogSlice';
 import { GetStaticProps } from 'next/types';
+import PageTitle from '../components/PageTitle';
 
 const Blog: React.FC = () => {
   const blog = useApplicationState((state) => state.blog);
@@ -19,7 +20,8 @@ const Blog: React.FC = () => {
 
   return (
     <React.Fragment>
-      <Layout pageTitle="Blog" contentTitle="Blog">
+      <Layout pageTitle="Blog">
+        <PageTitle text="Blog" />
         {blog.loaded ? (
           blog.posts.map((post: any, index: number) => <BlogPostCard key={index} post={post} />)
         ) : (

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -7,6 +7,8 @@ import { useApplicationState, useAppDispatch } from '../store';
 import { fetchBlogPosts } from '../store/blogSlice';
 import { GetStaticProps } from 'next/types';
 import PageTitle from '../components/PageTitle';
+import { Box } from '@mui/material';
+import { theme } from '../styles';
 
 const Blog: React.FC = () => {
   const blog = useApplicationState((state) => state.blog);
@@ -22,11 +24,13 @@ const Blog: React.FC = () => {
     <React.Fragment>
       <Layout pageTitle="Blog">
         <PageTitle text="Blog" />
-        {blog.loaded ? (
-          blog.posts.map((post: any, index: number) => <BlogPostCard key={index} post={post} />)
-        ) : (
-          <ListItemSkeleton />
-        )}
+        <Box sx={{ mt: theme.spacing(4) }}>
+          {blog.loaded ? (
+            blog.posts.map((post: any, index: number) => <BlogPostCard key={index} post={post} />)
+          ) : (
+            <ListItemSkeleton />
+          )}
+        </Box>
       </Layout>
     </React.Fragment>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,6 +7,7 @@ import FancyChild from '../components/FancyChild';
 import { fetchUserState } from '../lib/staticFetching';
 import { GetStaticProps } from 'next/types';
 import StyledLink from '../components/StyledLink';
+import PageTitle from '../components/PageTitle';
 
 const useStyles = makeStyles((theme: Theme) => ({
   interests: {
@@ -27,8 +28,9 @@ const Home: React.FC = () => {
 
   return (
     <React.Fragment>
-      <Layout pageTitle="About Me" contentTitle="Hi, I'm April.">
+      <Layout pageTitle="Home" showBioContent>
         <Box>
+          <PageTitle text="Hi, I'm April." />
           <Typography variant="h6" className={classes.summary} gutterBottom>
             {user.basics.summary}
           </Typography>

--- a/src/pages/projects.tsx
+++ b/src/pages/projects.tsx
@@ -8,6 +8,7 @@ import ProjectItem from '../components/ProjectItem';
 import { fetchUserState } from '../lib/staticFetching';
 import ListItemSkeleton from '../components/ListItemSkeleton';
 import { GetStaticProps } from 'next/types';
+import PageTitle from '../components/PageTitle';
 
 const useStyles = makeStyles((theme: Theme) => ({
   list: {
@@ -45,7 +46,8 @@ const Projects: React.FC = () => {
 
   return (
     <React.Fragment>
-      <Layout pageTitle="My Work" contentTitle="Projects & Samples">
+      <Layout pageTitle="Projects">
+        <PageTitle text="Projects & Samples" />
         <List className={classes.list}>
           {projectsState.loaded ? (
             projectsState.projects.map((project: ProjectType, index: number) => (


### PR DESCRIPTION
## Description

Removes the personal bio section (avatar, links, etc.) from all pages other than the home page. Also adds a "logo" (`aprilNeufeld` with a small version of the avatar) which brings the user directly back to Home. 

Some other small changes to styling have also been made.

## Changes

- Removed rounded edges on header & footer
- Extracted navbar from `Header` component into new `HeaderNavBar.tsx`
- Renamed `HeaderContent` => `HeaderBioContent` for clarity
- Made showing `HeaderBioContent` conditional (new prop in `Layout`)
- Moved certain styles into inline `sx` prop [experimental]
- Changed tab titles to be more descriptive
- Removed `PageTitle` component from `Layout` to individual pages

## Issues
Closes #23 
